### PR TITLE
remove css color white on icon hover

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -29,7 +29,6 @@ body {
 
 .fab:hover {
     text-decoration: none;
-    color: white;
     opacity: 0.7;
 }
 


### PR DESCRIPTION
Hover on icon made it disappear due to CSS rules, intended effect was to set opacity to 0.7.
![image](https://user-images.githubusercontent.com/1617242/67728764-3c7dcc80-f9cd-11e9-92fc-d8ef211e4951.png)
