### PR TITLE
fix: Add trailing slash to baseURL

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = "https://shreyaspatil.dev"
+baseURL = "https://shreyaspatil.dev/"
 languageCode = "en-us"
 title = "Shreyas Patil - Software Engineer (Mobile - Android, Kotlin, Open Source)"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@
   HUGO_ENABLEGITINFO = "true"
 
 [context.production]
-  command = "hugo --gc --minify --baseURL https://shreyaspatil.dev"
+  command = "hugo --gc --minify --baseURL https://shreyaspatil.dev/"
 
 [context.deploy-preview]
   command = "hugo --gc --minify --baseURL $DEPLOY_PRIME_URL"


### PR DESCRIPTION
Add trailing slash to baseURL in configuration to resolve redirect issue with query parameters.

---
*PR created automatically by Jules for task [14124822048651075856](https://jules.google.com/task/14124822048651075856) started by @PatilShreyas*