### PR TITLE
⚡ Bolt: Fix preload cache miss by using absURL for profile image

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-06-07 - Hugo Single-Page Portfolio Image Optimization
 **Learning:** This Hugo portfolio renders all sections (Experience, Community, Work) on a single `index.html` page, creating a large initial image payload (logos, project screenshots) that are far below the fold.
 **Action:** Always add `loading="lazy"` and `decoding="async"` to images in Hugo partials/sections that are rendered below the fold on single-page templates to prevent network bottlenecks on initial load.
+
+## 2026-06-14 - Preload Cache Misses due to Double Slashes
+**Learning:** In Hugo, when combining a strict trailing-slash `baseURL` (e.g. `https://shreyaspatil.dev/`) with paths starting with a slash (e.g. `/Images/profile-optimized.webp`), naive string concatenation (`{{ .Site.BaseURL }}{{ .Site.Params.profile_image }}`) results in a double slash (`//`). This double-slash URL forces a cache miss in the browser when the actual `<picture>` tag uses the single-slash URL, completely nullifying the performance benefit of `<link rel="preload">`!
+**Action:** Always use the built-in `absURL` pipe (e.g. `{{ .Site.Params.profile_image | absURL }}`) instead of manual string concatenation for asset URLs in Hugo layouts to ensure proper cache hits for preloaded resources.

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -32,7 +32,8 @@
     <!-- Preload Critical Resources -->
     <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"></noscript>
-    <link rel="preload" href="{{ .Site.BaseURL }}{{ .Site.Params.profile_image }}" as="image">
+    <!-- Use absURL to correctly handle the BaseURL trailing slash and prevent double-slash cache miss -->
+    <link rel="preload" href="{{ .Site.Params.profile_image | absURL }}" as="image">
     
     <!-- Fonts and CSS -->
     <link rel="stylesheet" href="{{ .Site.BaseURL }}css/fontawesome-minimal.css">


### PR DESCRIPTION
💡 What: Replaced manual string concatenation of BaseURL and profile image path with the Hugo built-in `absURL` pipe in `layouts/_default/baseof.html`. Also recorded this learning in `.jules/bolt.md`.
🎯 Why: Due to the strict trailing-slash requirement on `baseURL`, concatenating it with a leading-slash parameter like `/Images/profile-optimized.webp` produced a URL with double slashes (`//Images/...`). This URL mismatch with the actual `<img>` source caused a browser cache miss, negating the `link rel="preload"` optimization.
📊 Impact: Preloading now works correctly, ensuring the profile image is ready to render when the DOM is parsed, eliminating duplicate network requests and reducing LCP (Largest Contentful Paint) times.
🔬 Measurement: Verify generated HTML doesn't contain `//Images/` for the preload tag and check browser dev tools to confirm only one network request is made for the profile image.

---
*PR created automatically by Jules for task [5775677170134141542](https://jules.google.com/task/5775677170134141542) started by @PatilShreyas*