### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-06-07 - Hugo Single-Page Portfolio Image Optimization
 **Learning:** This Hugo portfolio renders all sections (Experience, Community, Work) on a single `index.html` page, creating a large initial image payload (logos, project screenshots) that are far below the fold.
 **Action:** Always add `loading="lazy"` and `decoding="async"` to images in Hugo partials/sections that are rendered below the fold on single-page templates to prevent network bottlenecks on initial load.
+
+## 2024-06-25 - Hugo URL Concatenation Cache Misses
+**Learning:** Using manual string concatenation with `{{ .Site.BaseURL }}` (e.g. `{{ .Site.BaseURL }}Images/...`) in Hugo templates can lead to double-slash (`//`) URL generation if the `baseURL` setting contains a trailing slash. This double slash causes browser cache misses for preloaded assets like images, fonts, and stylesheets, degrading initial load performance.
+**Action:** Always use the `absURL` or `relURL` pipe (e.g., `{{ "path/to/asset" | absURL }}`) instead of manually concatenating `.Site.BaseURL` with a path to ensure correct and normalized URL generation.

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,11 +10,11 @@
     <meta name="keywords" content="{{ .Site.Params.keywords }}">
     <meta name="author" content="{{ .Site.Params.author }}">
     <link rel="canonical" href="{{ .Permalink }}" />
-    <link rel="shortcut icon" href="{{ .Site.BaseURL }}Images/profile-optimized.png" type="image/png" />
+    <link rel="shortcut icon" href="{{ "Images/profile-optimized.png" | absURL }}" type="image/png" />
     
     <!-- Open Graph -->
     <meta property="og:title" content="{{ .Site.Title }}">
-    <meta property="og:image" content="{{ .Site.BaseURL }}Images/profile-optimized.png">
+    <meta property="og:image" content="{{ "Images/profile-optimized.png" | absURL }}">
     <meta property="og:description" content="{{ .Site.Params.description }}">
     <meta property="og:url" content="{{ .Permalink }}">
     <meta property="og:type" content="website">
@@ -23,7 +23,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="{{ .Site.Title }}">
     <meta name="twitter:description" content="{{ .Site.Params.description }}">
-    <meta name="twitter:image" content="{{ .Site.BaseURL }}Images/profile-optimized.png">
+    <meta name="twitter:image" content="{{ "Images/profile-optimized.png" | absURL }}">
     
     <!-- Resource Hints -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -32,11 +32,11 @@
     <!-- Preload Critical Resources -->
     <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"></noscript>
-    <link rel="preload" href="{{ .Site.BaseURL }}{{ .Site.Params.profile_image }}" as="image">
+    <link rel="preload" href="{{ .Site.Params.profile_image | absURL }}" as="image">
     
     <!-- Fonts and CSS -->
-    <link rel="stylesheet" href="{{ .Site.BaseURL }}css/fontawesome-minimal.css">
-    <link rel="stylesheet" href="{{ .Site.BaseURL }}css/tailwind.css">
+    <link rel="stylesheet" href="{{ "css/fontawesome-minimal.css" | absURL }}">
+    <link rel="stylesheet" href="{{ "css/tailwind.css" | absURL }}">
 </head>
 <body class="dark bg-dark-bg text-dark-text font-inter" style="background-color: #1b1b1b;">
     {{ block "header" . }}{{ partial "header.html" . }}{{ end }}
@@ -48,7 +48,7 @@
     {{ block "footer" . }}{{ partial "footer.html" . }}{{ end }}
     
     <!-- Scripts -->
-    <script src="{{ .Site.BaseURL }}js/main.js"></script>
+    <script src="{{ "js/main.js" | absURL }}"></script>
     
     
     <!-- Statcounter -->


### PR DESCRIPTION
💡 What: Replaced manual string concatenations (`{{ .Site.BaseURL }}...`) with the `absURL` pipe in `layouts/_default/baseof.html`.
🎯 Why: When the `baseURL` in Hugo configuration has a trailing slash, manual concatenation generates URLs with double slashes (e.g., `https://shreyaspatil.dev//Images/profile-optimized.png`). These double slashes cause browser cache misses for preloaded assets like images, fonts, and stylesheets, degrading initial load performance.
📊 Impact: Ensures correct URL generation, leading to successful caching of static assets across page reloads and saving bandwidth/network requests.
🔬 Measurement: Verify by checking the generated `index.html` after running the build process (e.g., `./hugo --minify`). The URLs should appear perfectly normalized (e.g., `https://shreyaspatil.dev/Images/profile-optimized.png`) instead of having double slashes.

---
*PR created automatically by Jules for task [10658475611245678965](https://jules.google.com/task/10658475611245678965) started by @PatilShreyas*